### PR TITLE
Recycle frame

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -19,5 +19,5 @@ bitflags = "2.9.1"
 num_enum = { version = "0.7.3", default-features = false }
 spin = { workspace = true }
 syscalls = { workspace = true }
-zerocopy = { version = "0.8.20", default-features = false }
+zerocopy = { workspace = true }
 log = "0.4"

--- a/services/kernel-thread/src/main.rs
+++ b/services/kernel-thread/src/main.rs
@@ -68,7 +68,7 @@ macro_rules! test_task {
     }};
 }
 
-const DEF_HEAP_SIZE: usize = 0x300_0000;
+const DEF_HEAP_SIZE: usize = 0x380_0000;
 
 sel4_runtime::define_heap!(DEF_HEAP_SIZE);
 

--- a/services/kernel-thread/src/syscall/thread.rs
+++ b/services/kernel-thread/src/syscall/thread.rs
@@ -26,7 +26,7 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use crate::{
     child_test::{ArcTask, TASK_MAP, WaitAnyChild, WaitPid, futex_requeue, futex_wake, wait_futex},
-    consts::task::{DEF_STACK_TOP, PAGE_COPY_TEMP},
+    consts::task::{DEF_HEAP_ADDR, DEF_STACK_TOP, PAGE_COPY_TEMP},
     task::Sel4Task,
     timer::{set_process_timer, wait_time},
     utils::page::map_page_self,
@@ -251,6 +251,7 @@ pub(super) async fn sys_clone(
                     );
                 });
         });
+        new_task.mem.lock().heap = old_mem_info.heap;
     }
 
     new_task
@@ -294,6 +295,7 @@ pub(super) fn sys_execve(
     let file = File::open(path, OpenFlags::RDONLY)?;
 
     task.clear_maped();
+    task.mem.lock().heap = DEF_HEAP_ADDR;
 
     let mut file_data = vec![0u8; file.file_size().unwrap()];
     file.read(&mut file_data)?;

--- a/services/kernel-thread/src/task/mem.rs
+++ b/services/kernel-thread/src/task/mem.rs
@@ -2,9 +2,8 @@
 //!
 //!
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
-use common::{config::PAGE_SIZE, page::PhysPage, slot::recycle_slot};
+use common::{config::PAGE_SIZE, page::PhysPage};
 use core::cmp;
-use sel4_kit::slot_manager::LeafSlot;
 
 use crate::consts::task::{DEF_HEAP_ADDR, DEF_STACK_BOTTOM, DEF_STACK_TOP};
 
@@ -184,10 +183,11 @@ impl Sel4Task {
     pub fn clear_maped(&self) {
         self.mem.lock().mapped_page.values().for_each(|x| {
             x.cap().frame_unmap().unwrap();
-            let slot = LeafSlot::from_cap(x.cap());
+            // self.capset.lock().recycle_page(x.cap());
+            let slot = sel4_kit::slot_manager::LeafSlot::from_cap(x.cap());
             slot.revoke().unwrap();
             slot.delete().unwrap();
-            recycle_slot(slot);
+            common::slot::recycle_slot(slot);
         });
         self.mem.lock().mapped_page.clear();
     }

--- a/tasks/simple-cli/Cargo.toml
+++ b/tasks/simple-cli/Cargo.toml
@@ -17,5 +17,5 @@ common = { workspace = true }
 sel4-kit = { workspace = true }
 
 uart-thread = { path = "../../services/uart-thread" }
-zerocopy = "0.8.25"
+zerocopy = { workspace = true }
 srv-gate = { workspace = true }


### PR DESCRIPTION
- 添加回收机制，在处理需要回收的 frame cap，并不是立即删除，而是存放到特定的地方，在需要继续申请 frame 的时候，并不是从 untyped 中派生，而是将回收的 frame cap 中的内存清空后继续使用。这种方式提高了 frame cap 的利用率，减少不断申请 frame 的情况
- 修复了 fork 的时候没有设置正确的 heap 的问题，这个问题曾导致 lmbench 在 fork 后进行大量操作的时候释放内存异常。